### PR TITLE
optimize babel file size

### DIFF
--- a/frontend/.babelrc
+++ b/frontend/.babelrc
@@ -1,4 +1,5 @@
 {
 	"presets": ["env"],
-  "compact": false
+  "plugins": ["transform-runtime"],
+  "compact": true
 }

--- a/frontend/gulpfile.babel.js
+++ b/frontend/gulpfile.babel.js
@@ -9,7 +9,6 @@ import webpack2 from 'webpack';
 import rimraf   from 'rimraf';
 import yaml     from 'js-yaml';
 import fs       from 'fs';
-import through  from 'through2';
 
 // Load all Gulp plugins into one variable
 const $ = plugins();
@@ -66,18 +65,9 @@ export const sass = () => gulp.src('src/assets/scss/app.scss')
 // In production, the file is minified
 export const javascript = () => gulp.src(PATHS.javascript)
   .pipe(webpack(require('./webpack.config.js'), webpack2))
-  .pipe($.sourcemaps.init({loadMaps: true}))
-  .pipe(through.obj(function (file, enc, cb) {
-    // Dont pipe through any source map files as it will be handled
-    // by gulp-sourcemaps
-    let isSourceMap = /\.map$/.test(file.path);
-    if (!isSourceMap) this.push(file);
-    cb();
-  }))
   .pipe($.if(PRODUCTION, $.uglify()
     .on('error', e => { console.log(e); })
   ))
-  .pipe($.if(!PRODUCTION, $.sourcemaps.write('./')))
   .pipe(gulp.dest(PATHS.dist + '/assets/js'));
 
 // Copy images to the "dist" folder
@@ -114,13 +104,9 @@ export const watch = () => {
 }
 
 // Build the "dist" folder by running all of the below tasks
-// gulp.task('build',
-//  gulp.series(clean, gulp.parallel(pages, sass, javascript, images, copy)));
 export const build = gulp.series(clean, gulp.parallel(pages, sass, javascript, images, data, fonts));
 
 // Build the site, run the server, and watch for file changes
-// gulp.task('default',
-//   gulp.series('build', server, watch));
 export const dev =  gulp.series(build, server, watch);
 
 export default dev;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,7 @@
     "animatewithsass": "^3.2.1",
     "babel-core": "^6.24.1",
     "babel-loader": "^7.0.0",
-    "babel-polyfill": "^6.23.0",
+    "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.4.0",
     "browser-sync": "^2.18.8",
     "bulma": "^0.4.1",
@@ -36,19 +36,16 @@
     "rimraf": "^2.6.1",
     "riot": "^3.4.4",
     "riot-route": "^3.1.1",
-    "through2": "^2.0.3",
     "webpack": "^2.5.0",
     "webpack-stream": "^3.2.0",
     "yargs": "^8.0.1"
   },
+  "dependencies": {
+    "babel-runtime": "^6.23.0"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/openstax/ostext-style-guide.git"
-  },
-  "babel": {
-    "presets": [
-      "env"
-    ]
   },
   "private": true
 }

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -2,7 +2,7 @@ const path = require('path');
 
 const config = {
   devtool: 'source-map',
-  entry: ['babel-polyfill', path.resolve(__dirname, 'src/assets/js/app.js')],
+  entry: path.resolve(__dirname, 'src/assets/js/app.js'),
   output: {
     path: path.resolve(__dirname, 'dist/assets/js'),
     filename: 'app.js'
@@ -13,10 +13,7 @@ const config = {
         test: /\.js$/,
         exclude: /(node_modules|bower_components)/,
         use: {
-          loader: 'babel-loader',
-          options: {
-            presets: ['env']
-          }
+          loader: 'babel-loader'
         }
       }
     ]

--- a/scripts/ostext_style_guide_scripts/style_guide_codmark.py
+++ b/scripts/ostext_style_guide_scripts/style_guide_codmark.py
@@ -18,6 +18,8 @@ from pygments.formatters import HtmlFormatter
 
 from pyparsing import makeHTMLTags, replaceWith, withAttribute
 
+cod = "../frontend/node_modules/.bin/cod"
+
 spanOpen,spanClose = makeHTMLTags("span")
 emptySpans = spanOpen.copy().setParseAction(withAttribute(empty=True))
 removeSpans = emptySpans | spanOpen+spanClose
@@ -81,7 +83,7 @@ A configuration file which consists of the following settings -
     file_paths.append(file_path)
   print("Found: {}".format(' '.join(file_paths)))
 
-  cod_output = subprocess.check_output("../frontend/node_modules/.bin/cod {}".format(' '.join(file_paths)), shell=True)
+  cod_output = subprocess.check_output(cod + " {}".format(' '.join(file_paths)), shell=True)
   style_guide_json = json.loads(cod_output.decode('utf-8'), object_hook=process_json_markup)
 
 


### PR DESCRIPTION
move all babel settings to .babelrc
replace babel-polyfill with babel-runtime & babel-plugin-transform-runtime to reduce app.js file size
fix webpack sourcemaps by removing gulp-sourcemaps pipe
move cod path to variable in style_guide_codmark.py